### PR TITLE
Merge back test utils into repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "@zkpassport/test-utils": "^0.2.2",
-    "@zkpassport/utils": "^0.2.4"
+    "@zkpassport/utils": "^0.2.9"
   },
   "dependencies": {
     "@zkpassport/poseidon2": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -15,26 +15,38 @@
   "devDependencies": {
     "@aws-sdk/client-cloudfront": "^3.730.0",
     "@aws-sdk/client-s3": "^3.730.0",
+    "@aztec/bb.js": "0.67.0",
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
+    "@lapo/asn1js": "^2.0.4",
+    "@noble/ciphers": "^1.0.0",
+    "@noble/curves": "^1.6.0",
+    "@noble/hashes": "^1.5.0",
+    "@noble/secp256k1": "^2.1.0",
+    "@noir-lang/noir_js": "1.0.0-beta.1",
+    "@noir-lang/noir_wasm": "1.0.0-beta.1",
+    "@peculiar/asn1-cms": "^2.3.15",
+    "@peculiar/asn1-ecc": "^2.3.15",
+    "@peculiar/asn1-rsa": "^2.3.15",
+    "@peculiar/asn1-schema": "^2.3.15",
+    "@peculiar/asn1-x509": "^2.3.15",
+    "@peculiar/webcrypto": "^1.5.0",
+    "@peculiar/x509": "^1.12.3",
     "@types/bun": "latest",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.10.1",
     "@types/node-forge": "^1.3.11",
+    "@zkpassport/utils": "^0.2.9",
     "aws-cdk": "^2.176.0",
     "aws-cdk-lib": "^2.176.0",
     "babel-jest": "^29.7.0",
     "constructs": "^10.4.2",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
-    "@zkpassport/test-utils": "^0.2.2",
-    "@zkpassport/utils": "^0.2.9"
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "@zkpassport/poseidon2": "^0.5.3",
     "node-forge": "^1.3.1"
-  },
-  "peerDependencies": {
-    "typescript": "^5.0.0"
   }
 }

--- a/scripts/ci-compile-circuits.sh
+++ b/scripts/ci-compile-circuits.sh
@@ -21,6 +21,7 @@ CIRCUITS=(
     "sig_check_id_data_tbs_700_ecdsa_nist_p256"
     "data_check_integrity"
     "disclose_flags"
+    "disclose_bytes"
     "inclusion_check_country"
     "exclusion_check_country"
     "compare_age"

--- a/src/ts/asn.ts
+++ b/src/ts/asn.ts
@@ -1,0 +1,173 @@
+import { Certificate as ASNCertificate } from "@peculiar/asn1-x509"
+import { AsnArray, AsnProp, AsnPropTypes, AsnType, AsnTypeTypes } from "@peculiar/asn1-schema"
+import {
+  Attribute as AsnAttribute,
+  ContentInfo as AsnContentInfo,
+  DigestAlgorithmIdentifier as AsnDigestAlgorithmIdentifier,
+  EncapsulatedContent as ASNEncapsulatedContent,
+  SignedAttributes as AsnSignedAttributes,
+  SignedData as AsnSignedData,
+  SignerIdentifier as AsnSignerIdentifier,
+  SignerInfo as AsnSignerInfo,
+} from "@peculiar/asn1-cms"
+
+export namespace ASN {
+  export const Attribute = AsnAttribute
+  export type Attribute = AsnAttribute
+  export const ContentInfo = AsnContentInfo
+  export type ContentInfo = AsnContentInfo
+  export const DigestAlgorithmIdentifier = AsnDigestAlgorithmIdentifier
+  export type DigestAlgorithmIdentifier = AsnDigestAlgorithmIdentifier
+  export const EncapsulatedContent = ASNEncapsulatedContent
+  export type EncapsulatedContent = ASNEncapsulatedContent
+  export const SignedData = AsnSignedData
+  export type SignedData = AsnSignedData
+  export const SignerInfo = AsnSignerInfo
+  export type SignerInfo = AsnSignerInfo
+  export const SignerIdentifier = AsnSignerIdentifier
+  export type SignerIdentifier = AsnSignerIdentifier
+  export type SignedAttributes = AsnSignedAttributes
+  export const Certificate = ASNCertificate
+  export type Certificate = ASNCertificate
+
+  /**
+   * ```asn
+   * AttributeSet ::= SET OF Attribute
+   * ```
+   */
+  @AsnType({ type: AsnTypeTypes.Set, itemType: AsnAttribute })
+  export class AttributeSet extends AsnArray<AsnAttribute> {
+    constructor(items?: AsnAttribute[]) {
+      super(items)
+
+      Object.setPrototypeOf(this, AttributeSet.prototype)
+    }
+  }
+
+  /**
+   * ```asn
+   * DataGroupHash ::= SEQUENCE {
+   *  dataGroupNumber DataGroupNumber,
+   *  dataGroupHashValue OCTET STRING }
+   * ```
+   */
+  export class DataGroupHash {
+    @AsnProp({ type: AsnPropTypes.Integer })
+    public number: DataGroupNumber = DataGroupNumber.dataGroup1
+
+    @AsnProp({ type: AsnPropTypes.OctetString })
+    public hash: ArrayBuffer = new ArrayBuffer(0)
+
+    public constructor(params: Partial<DataGroupHash> = {}) {
+      Object.assign(this, params)
+    }
+  }
+
+  /**
+   * ```asn
+   * LDSSecurityObjectVersion ::= INTEGER  { v0(0), v1(1) }
+   * ```
+   */
+  export enum LDSSecurityObjectVersion {
+    v0 = 0,
+    v1 = 1,
+    v2 = 2,
+  }
+
+  /**
+   * ```asn
+   * DataGroupNumber ::= INTEGER
+   * ```
+   */
+  export enum DataGroupNumber {
+    dataGroup1 = 1,
+    dataGroup2 = 2,
+    dataGroup3 = 3,
+    dataGroup4 = 4,
+    dataGroup5 = 5,
+    dataGroup6 = 6,
+    dataGroup7 = 7,
+    dataGroup8 = 8,
+    dataGroup9 = 9,
+    dataGroup10 = 10,
+    dataGroup11 = 11,
+    dataGroup12 = 12,
+    dataGroup13 = 13,
+    dataGroup14 = 14,
+    dataGroup15 = 15,
+    dataGroup16 = 16,
+  }
+
+  /**
+   * ```asn
+   * LDSVersionInfo ::= SEQUENCE {
+   *  ldsVersion PrintableString,
+   *  unicodeVersion PrintableString }
+   * ```
+   */
+  export class LDSVersionInfo {
+    @AsnProp({ type: AsnPropTypes.PrintableString })
+    public ldsVersion: string = ""
+
+    @AsnProp({ type: AsnPropTypes.PrintableString })
+    public unicodeVersion: string = ""
+
+    public constructor(params: Partial<LDSVersionInfo> = {}) {
+      Object.assign(this, params)
+    }
+  }
+
+  /**
+   * ```asn
+   * LDSSecurityObjectIdentifier ::= OBJECT IDENTIFIER
+   * ```
+   */
+  @AsnType({ type: AsnTypeTypes.Choice })
+  export class LDSSecurityObjectIdentifier {
+    @AsnProp({ type: AsnPropTypes.ObjectIdentifier })
+    public value: string = ""
+
+    constructor(value?: string) {
+      if (value) {
+        if (typeof value === "string") {
+          this.value = value
+        } else {
+          Object.assign(this, value)
+        }
+      }
+    }
+  }
+
+  /**
+   * This is for parsing the ASN of signedData.encapContentInfo.eContent
+   *
+   * ```asn
+   * LDSSecurityObject ::= SEQUENCE {
+   *  version LDSSecurityObjectVersion,
+   *  hashAlgorithm DigestAlgorithmIdentifier,
+   *  dataGroupHashValues SEQUENCE SIZE (2..ub-DataGroups) OF DataGroupHash,
+   *  ldsVersionInfo LDSVersionInfo OPTIONAL -- If present, version MUST be V1
+   * }
+   * ```
+   */
+  export class LDSSecurityObject {
+    @AsnProp({ type: AsnPropTypes.Integer })
+    public version: LDSSecurityObjectVersion = LDSSecurityObjectVersion.v1
+
+    @AsnProp({ type: AsnDigestAlgorithmIdentifier })
+    public hashAlgorithm: AsnDigestAlgorithmIdentifier = new AsnDigestAlgorithmIdentifier()
+
+    @AsnProp({ type: DataGroupHash, repeated: "sequence" })
+    public dataGroups: DataGroupHash[] = []
+
+    @AsnProp({ type: LDSVersionInfo, optional: true })
+    public versionInfo?: LDSVersionInfo
+
+    public constructor(params: Partial<LDSSecurityObject> = {}) {
+      Object.assign(this, params)
+    }
+  }
+}
+
+export const id_ldsSecurityObject = "2.23.136.1.1.1"
+export const id_sha256 = "2.16.840.1.101.3.4.2.1"

--- a/src/ts/circuits.ts
+++ b/src/ts/circuits.ts
@@ -1,0 +1,95 @@
+import { CompiledCircuit, InputMap, Noir } from "@noir-lang/noir_js"
+import { ProofData } from "@noir-lang/types"
+import { UltraHonkBackend } from "@aztec/bb.js"
+import fs from "fs"
+import path from "path"
+
+const BB_THREADS = 8
+
+export class Circuit {
+  private manifest: CompiledCircuit
+  private name: string
+  public backend?: UltraHonkBackend
+  public noir?: Noir
+
+  constructor(manifest: CompiledCircuit, name: string) {
+    this.manifest = manifest
+    this.name = name
+  }
+
+  async init() {
+    if (!this.backend) {
+      this.backend = new UltraHonkBackend(this.manifest.bytecode, {
+        threads: BB_THREADS,
+      })
+      if (!this.backend) throw new Error("Error initializing backend")
+    }
+    if (!this.noir) {
+      this.noir = new Noir(this.manifest)
+      if (!this.noir) throw new Error("Error initializing noir")
+    }
+  }
+
+  async destroy() {
+    if (!this.backend) return
+    await this.backend!.destroy()
+    this.backend = undefined
+  }
+
+  async solve(inputs: InputMap): Promise<Uint8Array> {
+    await this.init()
+    const { witness } = await this.noir!.execute(inputs)
+    if (!witness) throw new Error("Error solving witness")
+    return witness
+  }
+
+  async prove(inputs: InputMap, options?: { witness?: Uint8Array }): Promise<ProofData> {
+    await this.init()
+    const witness = options?.witness ?? (await this.solve(inputs))
+    const proof = await this.backend!.generateProof(witness)
+    return proof
+  }
+
+  async proveRecursiveProof(inputs: InputMap): Promise<{ proof: ProofData; artifacts: any }> {
+    const proof = await this.prove(inputs)
+    if (!this.backend) throw new Error("Backend not initialized")
+    const artifacts = await this.backend.generateRecursiveProofArtifacts(
+      proof.proof,
+      proof.publicInputs.length,
+    )
+    return { proof, artifacts }
+  }
+
+  async verify(proof: ProofData) {
+    await this.init()
+    if (!this.backend) throw new Error("Backend not initialized")
+    return await this.backend.verifyProof(proof)
+  }
+
+  async getVerificationKey() {
+    await this.init()
+    if (!this.backend) throw new Error("Backend not initialized")
+    return await this.backend.getVerificationKey()
+  }
+
+  static from(fileName: string): Circuit {
+    if (!path) throw new Error("Path is not available in this environment")
+    const isFullPath = path.isAbsolute(fileName) || fileName.includes("/")
+    const circuitPath = isFullPath ? fileName : path.resolve(`target/${fileName}.json`)
+    try {
+      if (!fs) throw new Error("Read file sync is not available in this environment")
+      const manifest = JSON.parse(fs.readFileSync(circuitPath, "utf-8"))
+      const name = path.basename(fileName, ".json")
+      return new Circuit(manifest, name)
+    } catch (error) {
+      if (error instanceof Error && error.name === "ENOENT") {
+        throw new Error(`No such file: target/${fileName}.json`)
+      }
+      throw error
+    }
+  }
+
+  getName(): string {
+    return this.name
+  }
+}

--- a/src/ts/passport-generator.ts
+++ b/src/ts/passport-generator.ts
@@ -1,0 +1,401 @@
+import { Binary } from "@zkpassport/utils"
+import { SignedData, SignerInfo, SignerInfos } from "@peculiar/asn1-cms"
+import { AsnConvert, AsnSerializer, OctetString } from "@peculiar/asn1-schema"
+import {
+  Certificate,
+  BasicConstraints,
+  KeyUsage,
+  SubjectKeyIdentifier,
+  AuthorityKeyIdentifier,
+  KeyIdentifier,
+} from "@peculiar/asn1-x509"
+import { cryptoProvider, PemConverter, X509CertificateGenerator, Extension } from "@peculiar/x509"
+import { ASN } from "./asn"
+import { wrapSodInContentInfo } from "./sod-generator"
+import fs from "fs"
+import { Crypto } from "@peculiar/webcrypto"
+
+const crypto = new Crypto()
+cryptoProvider.set(crypto as any)
+
+export type EcdsaCurve = "P-256" | "P-384" | "P-521"
+
+export type HashAlgorithm = "SHA-256" | "SHA-384" | "SHA-512"
+
+export type KeyPair = {
+  publicKey: Uint8Array
+  privateKey: Uint8Array
+  cryptoKey: {
+    publicKey: CryptoKey
+    privateKey: CryptoKey
+  }
+} & ({ type: "RSA"; modulusLength: number } | { type: "ECDSA"; curve: EcdsaCurve })
+
+export async function generateRsaKeyPair(
+  keySize: number,
+  hashAlgorithm: HashAlgorithm = "SHA-256",
+): Promise<KeyPair> {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: keySize,
+      publicExponent: new Uint8Array([1, 0, 1]), // 65537
+      hash: hashAlgorithm,
+    },
+    true,
+    ["sign", "verify"],
+  )
+
+  // Export the keys
+  const publicKeySpki = await crypto.subtle.exportKey("spki", keyPair.publicKey)
+  const privateKeyPkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey)
+
+  return {
+    publicKey: new Uint8Array(publicKeySpki),
+    privateKey: new Uint8Array(privateKeyPkcs8),
+    type: "RSA",
+    modulusLength: keySize,
+    cryptoKey: {
+      publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
+    },
+  }
+}
+
+export async function generateEcdsaKeyPair(curve: EcdsaCurve): Promise<KeyPair> {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve: curve,
+    },
+    true,
+    ["sign", "verify"],
+  )
+
+  const publicKeySpki = await crypto.subtle.exportKey("spki", keyPair.publicKey)
+  const privateKeyPkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey)
+
+  return {
+    publicKey: new Uint8Array(publicKeySpki),
+    privateKey: new Uint8Array(privateKeyPkcs8),
+    type: "ECDSA",
+    curve,
+    cryptoKey: {
+      publicKey: keyPair.publicKey,
+      privateKey: keyPair.privateKey,
+    },
+  }
+}
+
+export async function generateSigningCertificates({
+  cscSigningHashAlgorithm = "SHA-256",
+  cscKeyType = "ECDSA",
+  cscCurve = "P-521",
+  dscSigningHashAlgorithm = "SHA-256",
+  dscKeyType = "ECDSA",
+  dscCurve = "P-256",
+  cscKeySize = 4096,
+  dscKeySize = 2048,
+  dscKeypair,
+}: {
+  cscSigningHashAlgorithm?: HashAlgorithm
+  cscKeyType?: "RSA" | "ECDSA"
+  dscSigningHashAlgorithm?: HashAlgorithm
+  dscKeyType?: "RSA" | "ECDSA"
+  cscCurve?: EcdsaCurve
+  dscCurve?: EcdsaCurve
+  cscKeySize?: number
+  dscKeySize?: number
+  dscKeypair?: KeyPair
+} = {}) {
+  // Generate or use provided key pairs
+  const cscKeys =
+    cscKeyType === "RSA"
+      ? await generateRsaKeyPair(cscKeySize)
+      : await generateEcdsaKeyPair(cscCurve)
+
+  const dscKeys =
+    dscKeypair ||
+    (dscKeyType === "RSA"
+      ? await generateRsaKeyPair(dscKeySize)
+      : await generateEcdsaKeyPair(dscCurve))
+
+  const cscSubjectKeyIdentifier = await crypto.subtle.digest("SHA-256", cscKeys.publicKey)
+  const dscSubjectKeyIdentifier = await crypto.subtle.digest("SHA-256", dscKeys.publicKey)
+
+  // Create the root CSC
+  const cscCert = await generateCertificate({
+    subject: [
+      { type: "2.5.4.3", value: "ZKpassport Test Root CSC" },
+      { type: "2.5.4.6", value: "AU" },
+    ],
+    issuer: [
+      { type: "2.5.4.3", value: "ZKpassport Test Root CSC" },
+      { type: "2.5.4.6", value: "AU" },
+    ],
+    publicKey: cscKeys.publicKey,
+    signingKeyPair: cscKeys,
+    isCA: true,
+    validityYears: 10,
+    serialNumber: new Uint8Array([0x01]),
+    subjectKeyIdentifier: new Uint8Array(cscSubjectKeyIdentifier),
+  })
+
+  // Create the DSC
+  const dscCert = await generateCertificate({
+    subject: [{ type: "2.5.4.3", value: "ZKpassport Test DSC" }],
+    issuer: [
+      { type: "2.5.4.3", value: "ZKpassport Test Root CSC" },
+      { type: "2.5.4.6", value: "AU" },
+    ],
+    publicKey: dscKeys.publicKey,
+    signingKeyPair: cscKeys,
+    isCA: false,
+    validityYears: 2,
+    serialNumber: new Uint8Array([0x02]),
+    subjectKeyIdentifier: new Uint8Array(dscSubjectKeyIdentifier),
+    authorityKeyIdentifier: new Uint8Array(cscSubjectKeyIdentifier),
+  })
+
+  // Convert to PEM format
+  const cscPem = PemConverter.encode(AsnSerializer.serialize(cscCert), "CERTIFICATE")
+  const dscPem = PemConverter.encode(AsnSerializer.serialize(dscCert), "CERTIFICATE")
+
+  return {
+    csc: cscCert,
+    cscPem,
+    cscKeys,
+    dsc: dscCert,
+    dscPem,
+    dscKeys,
+  }
+}
+
+interface CertificateParams {
+  subject: { type: string; value: string }[]
+  issuer: { type: string; value: string }[]
+  publicKey: Uint8Array
+  signingKeyPair: KeyPair
+  isCA: boolean
+  validityYears: number
+  serialNumber?: Uint8Array
+  subjectKeyIdentifier?: Uint8Array
+  authorityKeyIdentifier?: Uint8Array
+}
+
+export async function generateCertificate(params: CertificateParams): Promise<Certificate> {
+  const extensions = [
+    new Extension(
+      "2.5.29.19", // basicConstraints
+      true,
+      AsnSerializer.serialize(new BasicConstraints({ cA: params.isCA })),
+    ),
+    new Extension(
+      "2.5.29.15", // keyUsage
+      true,
+      AsnSerializer.serialize(
+        new KeyUsage(
+          params.isCA ? 0x06 : 0x80, // keyCertSign + digitalSignature for CA, digitalSignature for DSC
+        ),
+      ),
+    ),
+    ...(params.subjectKeyIdentifier
+      ? [
+          new Extension(
+            "2.5.29.14", // subjectKeyIdentifier
+            false,
+            AsnSerializer.serialize(new SubjectKeyIdentifier(params.subjectKeyIdentifier)),
+          ),
+        ]
+      : []),
+    ...(params.authorityKeyIdentifier
+      ? [
+          new Extension(
+            "2.5.29.35", // authorityKeyIdentifier
+            false,
+            AsnSerializer.serialize(
+              new AuthorityKeyIdentifier({
+                keyIdentifier: new KeyIdentifier(params.authorityKeyIdentifier),
+              }),
+            ),
+          ),
+        ]
+      : []),
+  ]
+
+  const x509Certificate = await X509CertificateGenerator.create(
+    {
+      serialNumber: params.serialNumber ? Buffer.from(params.serialNumber).toString("hex") : "1",
+      notBefore: new Date(),
+      notAfter: new Date(new Date().getTime() + params.validityYears * 365 * 24 * 60 * 60 * 1000),
+      extensions: extensions,
+      subject: params.subject.map((attr) => `${attr.type}=${attr.value}`).join(","),
+      issuer: params.issuer.map((attr) => `${attr.type}=${attr.value}`).join(","),
+      publicKey: params.publicKey,
+      signingKey: params.signingKeyPair.cryptoKey.privateKey,
+    },
+    crypto as any,
+  )
+
+  // Convert to ASN.1 Certificate
+  const pemString = await x509Certificate.toString("pem")
+  const rawCert = PemConverter.decode(pemString)[0]
+  return AsnConvert.parse(rawCert, Certificate)
+}
+
+export async function signSod(sod: SignedData, signerKeys: KeyPair, hashAlgorithm: HashAlgorithm) {
+  const signedAttrs = new ASN.AttributeSet(sod.signerInfos[0]?.signedAttrs?.map((v) => v))
+  const signedAttrsBytes = AsnConvert.serialize(signedAttrs)
+
+  const algorithm =
+    signerKeys.type === "RSA"
+      ? { name: "RSASSA-PKCS1-v1_5", hash: hashAlgorithm }
+      : {
+          name: "ECDSA",
+          hash: hashAlgorithm,
+        }
+
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(algorithm, signerKeys.cryptoKey.privateKey, signedAttrsBytes),
+  )
+
+  const newSod = new SignedData({
+    version: sod.version,
+    digestAlgorithms: sod.digestAlgorithms,
+    encapContentInfo: sod.encapContentInfo,
+    certificates: sod.certificates,
+    signerInfos: new SignerInfos([
+      new SignerInfo({
+        version: sod.signerInfos[0].version,
+        sid: sod.signerInfos[0].sid,
+        digestAlgorithm: sod.signerInfos[0].digestAlgorithm,
+        signedAttrs: sod.signerInfos[0].signedAttrs,
+        signatureAlgorithm: sod.signerInfos[0].signatureAlgorithm,
+        signature: new OctetString(signature),
+      }),
+    ]),
+  })
+
+  return { signature, sod: newSod }
+}
+
+export function saveSodToFile(sod: SignedData, filePath: string) {
+  const encoded = AsnSerializer.serialize(wrapSodInContentInfo(sod))
+  if (!fs) {
+    throw new Error("File system operations are only available in Node.js environment")
+  }
+  fs.writeFileSync(filePath, Buffer.from(encoded))
+}
+
+export function saveCertificateToFile(certificate: Certificate, filePath: string) {
+  const encoded = AsnSerializer.serialize(certificate)
+  if (!fs) {
+    throw new Error("File system operations are only available in Node.js environment")
+  }
+  fs.writeFileSync(filePath, Buffer.from(encoded))
+}
+
+export function saveDG1ToFile(dg1: Binary, filePath: string) {
+  if (!fs) {
+    throw new Error("File system operations are only available in Node.js environment")
+  }
+  fs.writeFileSync(filePath, dg1.toBuffer())
+}
+
+export function saveKeypairToFile(
+  keypair: KeyPair,
+  filePath: string,
+  hashAlgorithm: HashAlgorithm = "SHA-256",
+) {
+  const keypairData = {
+    publicKey: Buffer.from(keypair.publicKey).toString("base64"),
+    privateKey: Buffer.from(keypair.privateKey).toString("base64"),
+    hashAlgorithm,
+    type: keypair.type,
+    ...(keypair.type === "RSA"
+      ? { modulusLength: keypair.modulusLength }
+      : { curve: keypair.curve }),
+  }
+  if (!fs) {
+    throw new Error("File system operations are only available in Node.js environment")
+  }
+  fs.writeFileSync(filePath, JSON.stringify(keypairData, null, 2))
+}
+
+export async function loadKeypairFromFile(filePath: string): Promise<KeyPair> {
+  if (!fs) {
+    throw new Error("File system operations are only available in Node.js environment")
+  }
+  const keypairData = JSON.parse(fs.readFileSync(filePath, "utf-8"))
+  const publicKey = Buffer.from(keypairData.publicKey, "base64")
+  const privateKey = Buffer.from(keypairData.privateKey, "base64")
+  const hashAlgorithm = keypairData.hashAlgorithm || "SHA-256"
+
+  if (keypairData.type === "RSA") {
+    const publicKeyCrypto = await crypto.subtle.importKey(
+      "spki",
+      publicKey,
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        hash: hashAlgorithm,
+      },
+      true,
+      ["verify"],
+    )
+
+    const privateKeyCrypto = await crypto.subtle.importKey(
+      "pkcs8",
+      privateKey,
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        hash: hashAlgorithm,
+      },
+      true,
+      ["sign"],
+    )
+
+    return {
+      publicKey,
+      privateKey,
+      type: "RSA",
+      modulusLength: keypairData.modulusLength,
+      cryptoKey: {
+        publicKey: publicKeyCrypto,
+        privateKey: privateKeyCrypto,
+      },
+    }
+  } else {
+    const publicKeyCrypto = await crypto.subtle.importKey(
+      "spki",
+      publicKey,
+      {
+        name: "ECDSA",
+        namedCurve: keypairData.curve,
+      },
+      true,
+      ["verify"],
+    )
+
+    const privateKeyCrypto = await crypto.subtle.importKey(
+      "pkcs8",
+      privateKey,
+      {
+        name: "ECDSA",
+        namedCurve: keypairData.curve,
+      },
+      true,
+      ["sign"],
+    )
+
+    return {
+      publicKey,
+      privateKey,
+      type: "ECDSA",
+      curve: keypairData.curve,
+      cryptoKey: {
+        publicKey: publicKeyCrypto,
+        privateKey: privateKeyCrypto,
+      },
+    }
+  }
+}

--- a/src/ts/scripts/circuit-builder.ts
+++ b/src/ts/scripts/circuit-builder.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs"
 import * as path from "path"
-import { compileCircuit } from "@zkpassport/test-utils"
 import { exec } from "child_process"
+import { compileCircuit } from "../utils"
 
 // Function to ensure directory exists
 function ensureDirectoryExistence(filePath: string) {

--- a/src/ts/scripts/generate-test-dsc-keypair.ts
+++ b/src/ts/scripts/generate-test-dsc-keypair.ts
@@ -1,6 +1,5 @@
-import forge from "node-forge"
 import * as path from "path"
-import { saveKeypairToFile, generateRsaKeyPair, generateEcdsaKeyPair } from "@zkpassport/test-utils"
+import { generateRsaKeyPair, generateEcdsaKeyPair, saveKeypairToFile } from "../passport-generator"
 
 // Generate a new DSC keypair
 console.log("Generating DSC keypair...")

--- a/src/ts/sod-generator.ts
+++ b/src/ts/sod-generator.ts
@@ -1,0 +1,238 @@
+import { ASN } from "./asn"
+import { Binary, id_ldsSecurityObject } from "@zkpassport/utils"
+import {
+  Attribute,
+  CertificateChoices,
+  CertificateSet,
+  ContentInfo,
+  DigestAlgorithmIdentifier,
+  DigestAlgorithmIdentifiers,
+  EncapsulatedContent,
+  EncapsulatedContentInfo,
+  id_signedData,
+  SignedData,
+  SignerIdentifier,
+  SignerInfo,
+  SignerInfos,
+  SigningTime,
+} from "@peculiar/asn1-cms"
+import {
+  AsnConvert,
+  AsnOctetStringConverter,
+  AsnSerializer,
+  BitString,
+  OctetString,
+} from "@peculiar/asn1-schema"
+import { id_sha256 } from "@peculiar/asn1-rsa"
+import {
+  AlgorithmIdentifier,
+  AttributeTypeAndValue,
+  AttributeValue,
+  BasicConstraints,
+  Certificate,
+  Extension,
+  Extensions,
+  KeyUsage,
+  Name,
+  RelativeDistinguishedName,
+  SubjectKeyIdentifier,
+  SubjectPublicKeyInfo,
+  TBSCertificate,
+  Validity,
+  Version,
+} from "@peculiar/asn1-x509"
+import { createHash } from "crypto"
+
+export function generateSampleDSC(): Certificate {
+  // Create subject and issuer names
+  const subjectName = new Name([
+    new RelativeDistinguishedName([
+      new AttributeTypeAndValue({
+        type: "2.5.4.6", // countryName
+        value: new AttributeValue({ ia5String: "DE" }),
+      }),
+      new AttributeTypeAndValue({
+        type: "2.5.4.10", // organizationName
+        value: new AttributeValue({
+          ia5String: "Test Country",
+        }),
+      }),
+    ]),
+  ])
+
+  // Create extensions
+  const extensions = new Extensions([
+    new Extension({
+      extnID: "2.5.29.19", // basicConstraints
+      critical: true,
+      extnValue: new OctetString(AsnConvert.serialize(new BasicConstraints({ cA: false }))),
+    }),
+    new Extension({
+      extnID: "2.5.29.15", // keyUsage
+      critical: true,
+      extnValue: new OctetString(AsnConvert.serialize(new KeyUsage(0x03))), // digitalSignature | keyCertSign
+    }),
+  ])
+
+  // Create dummy public key
+  const dummyPublicKey = new Uint8Array(256)
+  for (let i = 0; i < dummyPublicKey.length; i++) {
+    dummyPublicKey[i] = i % 256
+  }
+
+  // Create certificate
+  const tbsCertificate = new TBSCertificate({
+    version: Version.v3,
+    // @ts-ignore-error
+    serialNumber: new Uint8Array([1, 2, 3, 4, 5]),
+    signature: new AlgorithmIdentifier({
+      algorithm: "1.2.840.113549.1.1.11", // sha256WithRSAEncryption
+    }),
+    issuer: subjectName, // Self-signed for this example
+    validity: new Validity({
+      notBefore: new Date(),
+      notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year
+    }),
+    subject: subjectName,
+    subjectPublicKeyInfo: new SubjectPublicKeyInfo({
+      algorithm: new AlgorithmIdentifier({
+        algorithm: "1.2.840.113549.1.1.1", // rsaEncryption
+      }),
+      subjectPublicKey: AsnConvert.serialize(new BitString(dummyPublicKey)),
+    }),
+    extensions,
+  })
+  const certificate = new Certificate({
+    tbsCertificate,
+    signatureAlgorithm: new AlgorithmIdentifier({
+      algorithm: "1.2.840.113549.1.1.11", // sha256WithRSAEncryption
+    }),
+    signatureValue: AsnConvert.serialize(new BitString(dummyPublicKey)),
+  })
+  return certificate
+}
+
+export function generateSod(dg1: Binary, certificates: Certificate[] = []) {
+  // Digest Algorithms
+  const digestAlgorithms = new DigestAlgorithmIdentifiers([
+    new DigestAlgorithmIdentifier({
+      algorithm: id_sha256,
+    }),
+  ])
+
+  // Encapsulated Content Info
+  const dg1Hash = createHash("sha256").update(dg1.toBuffer()).digest()
+  const encapContentInfo = generateEncapContentInfo(dg1Hash)
+  const eContentHash = Binary.from(
+    createHash("sha256")
+      .update(Binary.from(encapContentInfo!.eContent!.single!.buffer).toBuffer())
+      .digest(),
+  )
+
+  // Signed Attributes
+  const signedAttrs = generateSignedAttrs(eContentHash)
+
+  // Create SignerInfo
+  const signerInfo = new SignerInfo({
+    version: 1,
+    sid: new SignerIdentifier({
+      subjectKeyIdentifier: new SubjectKeyIdentifier(new Uint8Array(32)),
+    }),
+    digestAlgorithm: new DigestAlgorithmIdentifier({
+      algorithm: id_sha256,
+    }),
+    signedAttrs: signedAttrs,
+    signatureAlgorithm: new AlgorithmIdentifier({
+      algorithm: certificates[0]?.signatureAlgorithm?.algorithm || "1.2.840.113549.1.1.11", // sha256WithRSAEncryption
+    }),
+    signature: new OctetString(new Uint8Array(256)),
+  })
+
+  // Create SOD (SignedData) structure
+  const sod = new SignedData({
+    version: 3,
+    digestAlgorithms,
+    encapContentInfo,
+    signerInfos: new SignerInfos([signerInfo]),
+    certificates: new CertificateSet(
+      certificates.map(
+        (cert) =>
+          new CertificateChoices({
+            certificate: cert,
+          }),
+      ),
+    ),
+  })
+
+  // Create the final ContentInfo wrapper
+  const contentInfo = new ContentInfo({
+    contentType: id_signedData,
+    content: AsnSerializer.serialize(sod),
+  })
+  return { contentInfo, sod }
+}
+
+export function wrapSodInContentInfo(sod: SignedData) {
+  const contentInfo = new ContentInfo({
+    contentType: id_signedData,
+    content: AsnSerializer.serialize(sod),
+  })
+  return contentInfo
+}
+
+export function generateEncapContentInfo(dg1Hash: Uint8Array) {
+  // Create LDS Security Object (SOD.encapContentInfo.eContent)
+  const ldsSecurityObject = new ASN.LDSSecurityObject()
+  ldsSecurityObject.version = ASN.LDSSecurityObjectVersion.v0
+  ldsSecurityObject.hashAlgorithm = new DigestAlgorithmIdentifier({
+    algorithm: id_sha256,
+  })
+
+  // Add some sample data group hashes
+  ldsSecurityObject.dataGroups = [
+    new ASN.DataGroupHash({
+      number: ASN.DataGroupNumber.dataGroup1,
+      // @ts-ignore-error
+      hash: dg1Hash,
+    }),
+    new ASN.DataGroupHash({
+      number: ASN.DataGroupNumber.dataGroup2,
+      // @ts-ignore-error
+      hash: new Uint8Array(32).buffer, // 32-byte zero buffer for testing
+    }),
+  ]
+
+  // Create EncapsulatedContentInfo container
+  const encapContentInfo = new EncapsulatedContentInfo({
+    eContentType: id_ldsSecurityObject,
+    eContent: new EncapsulatedContent({
+      single: new OctetString(AsnSerializer.serialize(ldsSecurityObject)),
+    }),
+  })
+  return encapContentInfo
+}
+
+export function generateSignedAttrs(eContentHash: Binary) {
+  const contentType = new Attribute({
+    attrType: "1.2.840.113549.1.9.3", // id_contentType
+    attrValues: [
+      AsnSerializer.serialize(new ASN.LDSSecurityObjectIdentifier(id_ldsSecurityObject)),
+    ],
+  })
+  const signingTime = new Attribute({
+    attrType: "1.2.840.113549.1.9.5", // id_signingTime
+    // Fix the time in UTC to avoid timezone issues
+    attrValues: [AsnConvert.serialize(new SigningTime(new Date("2024-05-01T00:00:00Z")))],
+  })
+  const messageDigest = new Attribute({
+    attrType: "1.2.840.113549.1.9.4", // id_messageDigest
+    // @ts-ignore-error
+    attrValues: [AsnConvert.serialize(AsnOctetStringConverter.toASN(eContentHash.toBuffer()))],
+  })
+  const signedAttrs: ASN.AttributeSet = new ASN.AttributeSet([
+    contentType,
+    signingTime,
+    messageDigest,
+  ])
+  return signedAttrs
+}

--- a/src/ts/test-helper.ts
+++ b/src/ts/test-helper.ts
@@ -1,0 +1,77 @@
+import fs from "fs/promises"
+import path from "path"
+import {
+  Binary,
+  PassportReader,
+  type CSCMasterlist,
+  type PassportViewModel,
+  type Query,
+  getDiscloseCircuitInputs,
+  getDSCCircuitInputs,
+  getIDDataCircuitInputs,
+  getIntegrityCheckCircuitInputs,
+} from "@zkpassport/utils"
+import { InputMap } from "@noir-lang/noir_js"
+
+type CircuitType = "dsc" | "id" | "integrity" | "disclose"
+
+export class TestHelper {
+  private passportReader = new PassportReader()
+  public passport!: PassportViewModel
+  private masterlist!: CSCMasterlist
+
+  setMasterlist(masterlist: CSCMasterlist) {
+    this.masterlist = masterlist
+  }
+
+  async generateCircuitInputs(circuitType: CircuitType): Promise<InputMap> {
+    switch (circuitType) {
+      case "dsc": {
+        const inputs = await getDSCCircuitInputs(
+          this.passport as any,
+          0n,
+          undefined,
+          this.masterlist,
+        )
+        if (!inputs) throw new Error("Unable to generate DSC circuit inputs")
+        return inputs
+      }
+      case "id": {
+        const inputs = await getIDDataCircuitInputs(this.passport as any, 0n)
+        if (!inputs) throw new Error("Unable to generate ID data circuit inputs")
+        return inputs
+      }
+      case "integrity": {
+        const inputs = await getIntegrityCheckCircuitInputs(this.passport as any, 0n)
+        if (!inputs) throw new Error("Unable to generate integrity check circuit inputs")
+        return inputs
+      }
+      case "disclose": {
+        const query: Query = {
+          fullname: { disclose: true },
+          nationality: { disclose: true },
+          birthdate: { disclose: true },
+        }
+        const inputs = await getDiscloseCircuitInputs(this.passport as any, query, 0n)
+        if (!inputs) throw new Error("Unable to generate disclose circuit inputs")
+        return inputs
+      }
+    }
+  }
+
+  public async loadPassportDataFromFile(dg1FileName: string, sodFileName: string): Promise<void> {
+    const FIXTURES_PATH = "src/ts/tests/fixtures"
+    if (!fs || !path) {
+      throw new Error("File system operations are only available in Node.js environment")
+    }
+    const dg1 = Binary.from(await fs.readFile(path.resolve(FIXTURES_PATH, dg1FileName)))
+    const sod = Binary.from(await fs.readFile(path.resolve(FIXTURES_PATH, sodFileName)))
+    this.passportReader.loadPassport(dg1, sod)
+    this.passport = this.passportReader.getPassportViewModel() as any
+  }
+
+  public async loadPassport(dg1: Binary, sod: Binary): Promise<void> {
+    this.passportReader.loadPassport(dg1, sod)
+    this.passport = this.passportReader.getPassportViewModel() as any
+  }
+}

--- a/src/ts/tests/circuits.test.ts
+++ b/src/ts/tests/circuits.test.ts
@@ -26,6 +26,7 @@ import {
   getCurrentDateFromIntegrityProof,
   getCurrentDateFromAgeProof,
   getCurrentDateFromDateProof,
+  getDiscloseCircuitInputs,
 } from "@zkpassport/utils"
 import {
   generateSigningCertificates,
@@ -63,7 +64,7 @@ describe("subcircuits - RSA PKCS", () => {
   beforeAll(async () => {
     // Johnny Silverhand's MRZ
     const mrz =
-      "P<AUSSILVERHAND<<JOHNNY<<<<<<<<<<<<<<<<<<<<<PA1234567_AUS881112_M300101_<CYBERCITY<<<<__"
+      "P<AUSSILVERHAND<<JOHNNY<<<<<<<<<<<<<<<<<<<<<PA1234567_AUS881112_M300101_<CYBERCITY<<<<\0\0"
     const dg1 = Binary.fromHex("615B5F1F58").concat(Binary.from(mrz))
     // Load DSC keypair
     const dscKeypair = await loadKeypairFromFile(DSC_KEYPAIR_PATH)
@@ -156,18 +157,20 @@ describe("subcircuits - RSA PKCS", () => {
       const proof = await circuit.prove(inputs, { witness: await circuit.solve(inputs) })
       expect(proof).toBeDefined()
       // Verify the disclosed data
-      const disclosedData = DisclosedData.fromProof(proof)
+      const disclosedData = DisclosedData.fromFlagsProof(proof)
       const nullifier = getNullifierFromDisclosureProof(proof)
       expect(disclosedData.issuingCountry).toBe("AUS")
       expect(disclosedData.nationality).toBe("AUS")
       expect(disclosedData.documentType).toBe("P")
       expect(disclosedData.documentNumber).toBe("PA1234567")
-      expect(disclosedData.name).toBe("SILVERHAND  JOHNNY")
+      expect(disclosedData.name).toBe("SILVERHAND JOHNNY")
+      expect(disclosedData.firstName).toBe("JOHNNY")
+      expect(disclosedData.lastName).toBe("SILVERHAND")
       expect(disclosedData.dateOfBirth).toEqual(new Date(1988, 10, 12))
       expect(disclosedData.dateOfExpiry).toEqual(new Date(2030, 0, 1))
       expect(disclosedData.gender).toBe("M")
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -182,18 +185,20 @@ describe("subcircuits - RSA PKCS", () => {
       const proof = await circuit.prove(inputs, { witness: await circuit.solve(inputs) })
       expect(proof).toBeDefined()
       // Verify the disclosed data
-      const disclosedData = DisclosedData.fromProof(proof)
+      const disclosedData = DisclosedData.fromFlagsProof(proof)
       const nullifier = getNullifierFromDisclosureProof(proof)
       expect(disclosedData.issuingCountry).toBe("")
       expect(disclosedData.nationality).toBe("AUS")
       expect(disclosedData.documentType).toBe("")
       expect(disclosedData.documentNumber).toBe("")
       expect(disclosedData.name).toBe("")
+      expect(disclosedData.firstName).toBe("")
+      expect(disclosedData.lastName).toBe("")
       expect(isNaN(disclosedData.dateOfBirth.getTime())).toBe(true)
       expect(isNaN(disclosedData.dateOfExpiry.getTime())).toBe(true)
       expect(disclosedData.gender).toBe("")
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -214,7 +219,7 @@ describe("subcircuits - RSA PKCS", () => {
       const nullifier = getNullifierFromDisclosureProof(proof)
       expect(countryList).toEqual(["AUS", "FRA", "USA", "GBR"])
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -240,7 +245,7 @@ describe("subcircuits - RSA PKCS", () => {
       // as it is required by the circuit
       expect(countryList).toEqual(["FRA", "GBR", "USA"])
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -265,7 +270,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(18)
       expect(maxAge).toBe(0)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -290,7 +295,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(0)
       expect(maxAge).toBe(age + 1)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -315,7 +320,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(age)
       expect(maxAge).toBe(age + 2)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -340,7 +345,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(age)
       expect(maxAge).toBe(age)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -365,7 +370,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(age)
       expect(maxAge).toBe(age)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -390,7 +395,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minAge).toBe(age - 5)
       expect(maxAge).toBe(age + 5)
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -417,7 +422,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1988, 10, 12))
       expect(maxDate).toEqual(new Date(1988, 10, 12))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -441,7 +446,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1988, 10, 11))
       expect(maxDate).toEqual(new Date(1988, 10, 13))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -465,7 +470,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1988, 10, 12))
       expect(maxDate).toEqual(new Date(1988, 10, 12))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -492,7 +497,7 @@ describe("subcircuits - RSA PKCS", () => {
       // as 00/00/0000 would throw an error
       expect(maxDate).toEqual(new Date(1111, 10, 11))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -516,7 +521,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1111, 10, 11))
       expect(maxDate).toEqual(new Date(1988, 10, 15))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -540,7 +545,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1988, 10, 11))
       expect(maxDate).toEqual(new Date(1988, 10, 15))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -566,7 +571,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(2030, 0, 1))
       expect(maxDate).toEqual(new Date(2030, 0, 1))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -590,7 +595,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(2025, 0, 1))
       expect(maxDate).toEqual(new Date(2035, 0, 1))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -614,7 +619,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(2030, 0, 1))
       expect(maxDate).toEqual(new Date(2030, 0, 1))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -639,7 +644,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(2025, 0, 1))
       expect(maxDate).toEqual(new Date(1111, 10, 11))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -663,7 +668,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(1111, 10, 11))
       expect(maxDate).toEqual(new Date(2035, 0, 1))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -687,7 +692,7 @@ describe("subcircuits - RSA PKCS", () => {
       expect(minDate).toEqual(new Date(2025, 0, 1))
       expect(maxDate).toEqual(new Date(2035, 0, 1))
       expect(nullifier).toEqual(
-        20991360808367981708700314199135452991004225667443406013167051877229082634759n,
+        10145717760157071414871097616712373356688301026314602642662418913725691010870n,
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
@@ -723,7 +728,7 @@ describe("subcircuits - ECDSA NIST P-384 and P-256", () => {
   beforeAll(async () => {
     // Johnny Silverhand's MRZ
     const mrz =
-      "P<AUSSILVERHAND<<JOHNNY<<<<<<<<<<<<<<<<<<<<<PA1234567_AUS881112_M300101_<CYBERCITY<<<<__"
+      "P<AUSSILVERHAND<<JOHNNY<<<<<<<<<<<<<<<<<<<<<PA1234567_AUS881112_M300101_<CYBERCITY<<<<\0\0"
     const dg1 = Binary.fromHex("615B5F1F58").concat(Binary.from(mrz))
     // Load DSC keypair
     const dscKeypair = await loadKeypairFromFile(DSC_KEYPAIR_PATH)
@@ -794,13 +799,13 @@ describe("subcircuits - ECDSA NIST P-384 and P-256", () => {
   describe("disclose", () => {
     let circuit: Circuit
     beforeAll(async () => {
-      circuit = Circuit.from("disclose_flags")
+      circuit = Circuit.from("disclose_bytes")
     })
     afterAll(async () => {
       await circuit.destroy()
     })
 
-    test("disclose all flags", async () => {
+    test("disclose all bytes", async () => {
       const query: Query = {
         issuing_country: { disclose: true },
         nationality: { disclose: true },
@@ -811,18 +816,20 @@ describe("subcircuits - ECDSA NIST P-384 and P-256", () => {
         expiry_date: { disclose: true },
         gender: { disclose: true },
       }
-      let inputs = await getDiscloseFlagsCircuitInputs(helper.passport as any, query, 0n)
+      let inputs = await getDiscloseCircuitInputs(helper.passport as any, query, 0n)
       if (!inputs) throw new Error("Unable to generate disclose circuit inputs")
       const proof = await circuit.prove(inputs, { witness: await circuit.solve(inputs) })
       expect(proof).toBeDefined()
       // Verify the disclosed data
-      const disclosedData = DisclosedData.fromProof(proof)
+      const disclosedData = DisclosedData.fromBytesProof(proof, "passport")
       globalNullifier = getNullifierFromDisclosureProof(proof)
       expect(disclosedData.issuingCountry).toBe("AUS")
       expect(disclosedData.nationality).toBe("AUS")
       expect(disclosedData.documentType).toBe("P")
       expect(disclosedData.documentNumber).toBe("PA1234567")
-      expect(disclosedData.name).toBe("SILVERHAND  JOHNNY")
+      expect(disclosedData.name).toBe("SILVERHAND JOHNNY")
+      expect(disclosedData.firstName).toBe("JOHNNY")
+      expect(disclosedData.lastName).toBe("SILVERHAND")
       expect(disclosedData.dateOfBirth).toEqual(new Date(1988, 10, 12))
       expect(disclosedData.dateOfExpiry).toEqual(new Date(2030, 0, 1))
       expect(disclosedData.gender).toBe("M")
@@ -831,22 +838,24 @@ describe("subcircuits - ECDSA NIST P-384 and P-256", () => {
       expect(commitmentIn).toEqual(integrityCheckCommitment)
     })
 
-    test("disclose some flags", async () => {
+    test("disclose some bytes", async () => {
       const query: Query = {
         nationality: { disclose: true },
       }
-      let inputs = await getDiscloseFlagsCircuitInputs(helper.passport as any, query, 0n)
+      let inputs = await getDiscloseCircuitInputs(helper.passport as any, query, 0n)
       if (!inputs) throw new Error("Unable to generate disclose circuit inputs")
       const proof = await circuit.prove(inputs, { witness: await circuit.solve(inputs) })
       expect(proof).toBeDefined()
       // Verify the disclosed data
-      const disclosedData = DisclosedData.fromProof(proof)
+      const disclosedData = DisclosedData.fromBytesProof(proof, "passport")
       const nullifier = getNullifierFromDisclosureProof(proof)
       expect(disclosedData.issuingCountry).toBe("")
       expect(disclosedData.nationality).toBe("AUS")
       expect(disclosedData.documentType).toBe("")
       expect(disclosedData.documentNumber).toBe("")
       expect(disclosedData.name).toBe("")
+      expect(disclosedData.firstName).toBe("")
+      expect(disclosedData.lastName).toBe("")
       expect(isNaN(disclosedData.dateOfBirth.getTime())).toBe(true)
       expect(isNaN(disclosedData.dateOfExpiry.getTime())).toBe(true)
       expect(disclosedData.gender).toBe("")

--- a/src/ts/tests/circuits.test.ts
+++ b/src/ts/tests/circuits.test.ts
@@ -28,19 +28,16 @@ import {
   getCurrentDateFromDateProof,
   getDiscloseCircuitInputs,
 } from "@zkpassport/utils"
-import {
-  generateSigningCertificates,
-  loadKeypairFromFile,
-  signSod,
-  generateSod,
-  wrapSodInContentInfo,
-  TestHelper,
-  Circuit,
-  serializeAsn,
-} from "@zkpassport/test-utils"
 import type { CSCMasterlist, Query } from "@zkpassport/utils"
 import { beforeAll, describe, expect, test } from "@jest/globals"
 import * as path from "path"
+import { TestHelper } from "../test-helper"
+import { generateSigningCertificates, signSod } from "../passport-generator"
+import { loadKeypairFromFile } from "../passport-generator"
+import { wrapSodInContentInfo } from "../sod-generator"
+import { generateSod } from "../sod-generator"
+import { serializeAsn } from "../utils"
+import { Circuit } from "../circuits"
 
 describe("subcircuits - RSA PKCS", () => {
   const helper = new TestHelper()

--- a/src/ts/tests/sod-generator.test.ts
+++ b/src/ts/tests/sod-generator.test.ts
@@ -1,0 +1,53 @@
+import { id_signedData, SignedData } from "@peculiar/asn1-cms"
+import { AsnConvert } from "@peculiar/asn1-schema"
+import { Version } from "@peculiar/asn1-x509"
+import { describe, it, expect } from "@jest/globals"
+import { generateSampleDSC, generateSod } from "../sod-generator"
+import { Binary, id_sha256 } from "@zkpassport/utils"
+import { createHash } from "crypto"
+import { ASN } from "../asn"
+
+describe("SOD", () => {
+  const dg1 = Binary.from(new Uint8Array(32).buffer)
+  const dg1Hash = createHash("sha256").update(dg1.toBuffer()).digest()
+
+  it("generate SOD", async () => {
+    const { contentInfo } = await generateSod(dg1)
+    expect(contentInfo.contentType).toBe(id_signedData)
+    // Verify the structure can be parsed back
+    const sod = AsnConvert.parse(contentInfo.content, SignedData)
+    const eContent = AsnConvert.parse(
+      sod?.encapContentInfo?.eContent?.single!,
+      ASN.LDSSecurityObject,
+    )
+    // Verify the decoded content
+    expect(eContent.version).toBe(ASN.LDSSecurityObjectVersion.v0)
+    expect(eContent.hashAlgorithm.algorithm).toBe(id_sha256)
+    expect(eContent.dataGroups.length).toBe(2)
+    expect(eContent.dataGroups[0].number).toBe(ASN.DataGroupNumber.dataGroup1)
+    expect(eContent.dataGroups[1].number).toBe(ASN.DataGroupNumber.dataGroup2)
+    expect(Binary.from(eContent.dataGroups[0].hash)).toEqual(Binary.from(dg1Hash))
+    // Verify signer info
+    expect(sod.signerInfos.length).toBe(1)
+    const decodedSignerInfo = sod.signerInfos[0]
+    expect(decodedSignerInfo.version).toBe(1)
+    expect(decodedSignerInfo?.signedAttrs?.length).toBe(3)
+    // Verify certificates
+    expect(Array.isArray(sod.certificates)).toBe(true)
+    expect(sod.certificates?.length).toBe(0) // Default empty certificates
+  })
+
+  it("generate SOD with sample DSC", async () => {
+    const sampleDSC = generateSampleDSC()
+    const { contentInfo } = await generateSod(dg1, [sampleDSC])
+    // Verify the structure can be parsed back
+    const sod = AsnConvert.parse(contentInfo.content, SignedData)
+    // Verify certificates
+    expect(Array.isArray(sod.certificates)).toBe(true)
+    expect(sod!.certificates!.length).toBe(1)
+    const cert = sod!.certificates![0]!.certificate
+    expect(!!cert).toBe(true)
+    expect(cert!.tbsCertificate.version).toBe(Version.v3)
+    expect(cert!.tbsCertificate.serialNumber.byteLength).toBe(5)
+  })
+})

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,0 +1,32 @@
+import { CompiledCircuit } from "@noir-lang/types"
+import { readFile } from "fs/promises"
+import { createFileManager, compile_program } from "@noir-lang/noir_wasm"
+import { AsnSerializer } from "@peculiar/asn1-schema"
+
+/**
+ * Loads a circuit manifest from a JSON file.
+ * @param filename - The path to the JSON file.
+ * @returns The compiled circuit.
+ */
+export async function loadCircuitManifest(filename: string): Promise<CompiledCircuit> {
+  try {
+    return JSON.parse(await readFile(filename, "utf-8"))
+  } catch (error) {
+    throw new Error(`${filename} is not valid JSON`)
+  }
+}
+
+/**
+ * Compiles a circuit from the specified path.
+ * @param path - The path to the circuit file.
+ * @returns The compiled circuit.
+ */
+export async function compileCircuit(path: string): Promise<CompiledCircuit> {
+  const fm = createFileManager(path)
+  const myCompiledCode = await compile_program(fm)
+  return myCompiledCode.program
+}
+
+export function serializeAsn(obj: any): ArrayBuffer {
+  return AsnSerializer.serialize(obj)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "target": "esnext",
+    "module": "ESNext",
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/ts/*"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
The main goal of creating a separate utils library was to have code that can be shared across multiple repos (including the mobile app and SDK) and for it to support Node.js, the browser, and React Native. 
The separate test utils lib didn't make as much sense since it is only meant to work in a Node.js environment and is specific to the circuits repo. Therefore, this PR merges back the code from the test utils lib into the repo