### PR TITLE
chore: switch to use external sha256 lib

### DIFF
--- a/src/noir/lib/data-check/integrity/Nargo.toml
+++ b/src/noir/lib/data-check/integrity/Nargo.toml
@@ -6,3 +6,4 @@ compiler_version = ">=0.22.0"
 
 [dependencies]
 utils = { path = "../../utils" }
+sha256 = { tag = "v0.1.1", git = "https://github.com/noir-lang/sha256" }

--- a/src/noir/lib/data-check/integrity/src/lib.nr
+++ b/src/noir/lib/data-check/integrity/src/lib.nr
@@ -1,5 +1,4 @@
 use utils::is_id_card;
-use std::sha256;
 
 /**
 * Computes the hash of the MRZ (Data Group 1) and checks it is the same as the one

--- a/src/noir/lib/sig-check/ecdsa/Nargo.toml
+++ b/src/noir/lib/sig-check/ecdsa/Nargo.toml
@@ -9,3 +9,4 @@ utils = { path = "../../utils" }
 ecdsa = { tag = "v0.2.0", git = "https://github.com/zkpassport/noir-ecdsa" }
 bignum = {tag = "v0.5.0", git = "https://github.com/noir-lang/noir-bignum"}
 bigcurve = {tag = "v0.2.0", git = "https://github.com/madztheo/noir_bigcurve"}
+sha256 = { tag = "v0.1.1", git = "https://github.com/noir-lang/sha256" }

--- a/src/noir/lib/sig-check/ecdsa/src/lib.nr
+++ b/src/noir/lib/sig-check/ecdsa/src/lib.nr
@@ -26,7 +26,6 @@ use ecdsa::ecdsa::{
     verify_secp256r1_ecdsa, verify_secp384r1_ecdsa, verify_secp521r1_ecdsa,
 };
 use std::ecdsa_secp256r1;
-use std::hash::sha256;
 use utils::{
     check_zero_padding, concat_array, ECDSA_CURVE_BRAINPOOL_B256R1, ECDSA_CURVE_BRAINPOOL_B256T1,
     ECDSA_CURVE_BRAINPOOL_B384R1, ECDSA_CURVE_BRAINPOOL_B384T1, ECDSA_CURVE_BRAINPOOL_B512R1,


### PR DESCRIPTION
We're deprecating sha256 out of the stdlib and moving it into a library. This PR replaces the calls to the stdlib implementation of sha256 with calls to this library.