### PR TITLE
Circuit size in circuit packager

### DIFF
--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -2,4 +2,4 @@
 package_name=$1
 
 # Compile the circuit and get the number of the gates
-nargo compile --force --package $package_name && bb gates -b ./target/$package_name.json > ./info/$package_name.json
+nargo compile --force --package $package_name && bb gates -b ./target/$package_name.json --recursive > ./info/$package_name.json

--- a/src/ts/scripts/circuit-packager.ts
+++ b/src/ts/scripts/circuit-packager.ts
@@ -82,7 +82,7 @@ const processFiles = async () => {
         await execPromise(
           `bb vk_as_fields_ultra_honk -k "${vkeyPath}" -o "${vkeyJsonPath}" --recursive`,
         )
-        await execPromise(`bb gates -b "${inputPath}" > "${gateCountPath}"`)
+        await execPromise(`bb gates -b "${inputPath}" --recursive > "${gateCountPath}"`)
 
         // Get Poseidon2 hash of vkey
         const vkeyAsFieldsJson = JSON.parse(fs.readFileSync(vkeyJsonPath, "utf-8"))


### PR DESCRIPTION
Compute and save the gate count for each circuit in the circuit packer in order to avoid having to compute the circuit size dynamically in the mobile app