### PR TITLE
feat: Add support for more RSA exponents (up to 2^17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "circuits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "circuits",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@aws-sdk/client-cloudfront": "^3.730.0",
         "@aws-sdk/client-s3": "^3.730.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circuits",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "scripts": {
     "lint": "tsc --project src/ts/tsconfig.json --noEmit && nargo fmt --check",
     "test": "jest",

--- a/scripts/prove-honk.sh
+++ b/scripts/prove-honk.sh
@@ -7,4 +7,4 @@ nargo execute --package $package_name ${package_name}_witness
 mkdir -p ./proofs/${package_name}_honk
 
 # Generate a Honk proof for the circuit with the witness generated just before
-time bb prove --scheme ultra_honk -b ./target/$package_name.json -w ./target/${package_name}_witness.gz -o ./proofs/${package_name}_honk
+time bb prove --scheme ultra_honk -b ./target/$package_name.json -w ./target/${package_name}_witness.gz -o ./proofs/${package_name}_honk --write_vk --verify

--- a/src/noir/lib/sig-check/rsa/Nargo.toml
+++ b/src/noir/lib/sig-check/rsa/Nargo.toml
@@ -5,7 +5,7 @@ authors = ["Theo Madzou", "Michael Elliot"]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-rsa = { git = "https://github.com/zkpassport/noir_rsa", tag = "v0.8.3" }
+rsa = { git = "https://github.com/zkpassport/noir_rsa", tag = "v0.9.0" }
 bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.7.3"}
 utils = { path = "../../utils" }
 common = { path = "../common" }


### PR DESCRIPTION
This PR updates the RSA library to its latest version to add support for exponents all the way up to 2^17. This results in slightly more constraints in each circuit using RSA, but still reasonable, keeping all circuits in the subgroup 2^20 or below.
This will add support for some passports using uncommon exponents (i.e. neither 65537 nor 3), such as notably passports from Nigeria.