### PR TITLE
feat: Check sorting of country exclusion list in circuit

### DIFF
--- a/src/noir/bin/exclusion-check/issuing-country/evm/src/main.nr
+++ b/src/noir/bin/exclusion-check/issuing-country/evm/src/main.nr
@@ -11,9 +11,10 @@ fn main(
     // There are roughly 200 countries in the world
     // so we can safely pad it to 200
     // The list must be sorted in ascending order
-    // For efficiency, no sorting is done in the circuit
-    // since the fact that the list is already sorted can checked
-    // by any verifier passing the public inputs to verify the proof
+    // For efficiency, the list is not sorted in the circuit
+    // but it is checked to be sorted.
+    // So it is up to the prover to properly sort the list before passing it to the circuit
+    // or the proof will fail to generate
     country_list: [u32; 200],
     service_scope: pub Field,
     service_subscope: pub Field,

--- a/src/noir/bin/exclusion-check/issuing-country/standard/src/main.nr
+++ b/src/noir/bin/exclusion-check/issuing-country/standard/src/main.nr
@@ -11,9 +11,10 @@ fn main(
     // There are roughly 200 countries in the world
     // so we can safely pad it to 200
     // The list must be sorted in ascending order
-    // For efficiency, no sorting is done in the circuit
-    // since the fact that the list is already sorted can checked
-    // by any verifier passing the public inputs to verify the proof
+    // For efficiency, the list is not sorted in the circuit
+    // but it is checked to be sorted.
+    // So it is up to the prover to properly sort the list before passing it to the circuit
+    // or the proof will fail to generate
     country_list: [u32; 200],
     service_scope: pub Field,
     service_subscope: pub Field,

--- a/src/noir/bin/exclusion-check/nationality/evm/src/main.nr
+++ b/src/noir/bin/exclusion-check/nationality/evm/src/main.nr
@@ -10,10 +10,10 @@ fn main(
     // @committed
     // There are roughly 200 countries in the world
     // so we can safely pad it to 200
-    // The list must be sorted in ascending order
-    // For efficiency, no sorting is done in the circuit
-    // since the fact that the list is already sorted can checked
-    // by any verifier passing the public inputs to verify the proof
+    // For efficiency, the list is not sorted in the circuit
+    // but it is checked to be sorted.
+    // So it is up to the prover to properly sort the list before passing it to the circuit
+    // or the proof will fail to generate
     country_list: [u32; 200],
     service_scope: pub Field,
     service_subscope: pub Field,

--- a/src/noir/bin/exclusion-check/nationality/standard/src/main.nr
+++ b/src/noir/bin/exclusion-check/nationality/standard/src/main.nr
@@ -11,9 +11,10 @@ fn main(
     // There are roughly 200 countries in the world
     // so we can safely pad it to 200
     // The list must be sorted in ascending order
-    // For efficiency, no sorting is done in the circuit
-    // since the fact that the list is already sorted can checked
-    // by any verifier passing the public inputs to verify the proof
+    // For efficiency, the list is not sorted in the circuit
+    // but it is checked to be sorted.
+    // So it is up to the prover to properly sort the list before passing it to the circuit
+    // or the proof will fail to generate
     country_list: [u32; 200],
     service_scope: pub Field,
     service_subscope: pub Field,

--- a/src/noir/lib/exclusion-check/country/src/lib.nr
+++ b/src/noir/lib/exclusion-check/country/src/lib.nr
@@ -26,6 +26,7 @@ unconstrained fn get_last_index<let N: u32>(sorted_list: [u32; N]) -> i64 {
 pub fn check_country_list_sorted<let N: u32>(country_list: [u32; N]) -> bool {
     let mut result = true;
     let mut foundAZero = false;
+    assert(country_list[0] != 0, "Country list cannot start with 0");
     for i in 0..N - 1 {
         // Zeroes mark the end of the list (i.e. start of the padding)
         if !foundAZero & (country_list[i + 1] == 0) {
@@ -36,8 +37,46 @@ pub fn check_country_list_sorted<let N: u32>(country_list: [u32; N]) -> bool {
         if !foundAZero & (country_list[i] >= country_list[i + 1]) {
             result = false;
         }
+        if (foundAZero) {
+            assert(
+                country_list[i + 1] == 0,
+                "Country list cannot contain 0s before the last non-0 element",
+            );
+        }
     }
     result
+}
+
+fn check_exclusion<let N: u32>(country_sum: u32, country_list: [u32; N]) {
+    // Safety: since the list is assumed to be sorted in ascending order, we can get the index to check against
+    // from an unconstrained function
+    let closest_index = unsafe { get_closest_index(country_list, country_sum) };
+    if closest_index == -1 {
+        // Safety: get the index of the last element in the list that is not 0
+        let last_index = unsafe { get_last_index(country_list) };
+        assert(country_list[last_index as u32] > 0);
+        if last_index < (N - 1) as i64 {
+            // If there are still 0s after the last non-0 element,
+            // then we need to check that the next element is 0
+            assert_eq(country_list[last_index as u32 + 1], 0);
+        }
+        // If the index is -1, then the nationality sum is greater than all the elements in the list
+        assert(country_list[last_index as u32] < country_sum);
+    }
+    // Assert that either the index is the first element of the list or the previous element is less than the nationality sum
+    else if closest_index == 0 {
+        // Assert that the country at the index is greater than the nationality sum
+        assert(country_list[closest_index as u32] > country_sum);
+    }
+    // Cannot be done in a single if statement otherwise the second check will fail if closest_index is 0
+    else if country_list[closest_index as u32 - 1] < country_sum {
+        // Assert that the country at the index is greater than the nationality sum
+        assert(country_list[closest_index as u32] > country_sum);
+    } else {
+        // Otherwise it should fail
+        assert(false);
+    }
+    // If those two checks pass, then the nationality is not in the country list
 }
 
 /// Check if the nationality from the MRZ is not in the country list
@@ -64,35 +103,7 @@ pub fn check_nationality_exclusion<let N: u32>(dg1: [u8; 95], country_list: [u32
         + nationality_bytes[1] as u32 * 0x100
         + nationality_bytes[2] as u32;
 
-    // Safety: since the list is assumed to be sorted in ascending order, we can get the index to check against
-    // from an unconstrained function
-    let closest_index = unsafe { get_closest_index(country_list, nationality_sum) };
-    if closest_index == -1 {
-        // Safety: get the index of the last element in the list that is not 0
-        let last_index = unsafe { get_last_index(country_list) };
-        assert(country_list[last_index as u32] > 0);
-        if last_index < (N - 1) as i64 {
-            // If there are still 0s after the last non-0 element,
-            // then we need to check that the next element is 0
-            assert_eq(country_list[last_index as u32 + 1], 0);
-        }
-        // If the index is -1, then the nationality sum is greater than all the elements in the list
-        assert(country_list[last_index as u32] < nationality_sum);
-    }
-    // Assert that either the index is the first element of the list or the previous element is less than the nationality sum
-    else if closest_index == 0 {
-        // Assert that the country at the index is greater than the nationality sum
-        assert(country_list[closest_index as u32] > nationality_sum);
-    }
-    // Cannot be done in a single if statement otherwise the second check will fail if closest_index is 0
-    else if country_list[closest_index as u32 - 1] < nationality_sum {
-        // Assert that the country at the index is greater than the nationality sum
-        assert(country_list[closest_index as u32] > nationality_sum);
-    } else {
-        // Otherwise it should fail
-        assert(false);
-    }
-    // If those two checks pass, then the nationality is not in the country list
+    check_exclusion(nationality_sum, country_list);
 }
 
 /// Check if the issuing country from the MRZ is not in the country list
@@ -112,37 +123,7 @@ pub fn check_issuing_country_exclusion<let N: u32>(dg1: [u8; 95], country_list: 
         + issuing_country_bytes[1] as u32 * 0x100
         + issuing_country_bytes[2] as u32;
 
-    // Safety: since the list is assumed to be sorted in ascending order, we can get the index to check against
-    // from an unconstrained function
-    let closest_index = unsafe { get_closest_index(country_list, issuing_country_sum) };
-
-    // Safety: since the list is assumed to be sorted in ascending order, we can get the index to check against
-    // from an unconstrained function
-    let closest_index = unsafe { get_closest_index(country_list, issuing_country_sum) };
-    if closest_index == -1 {
-        // Safety: get the index of the last element in the list that is not 0
-        let last_index = unsafe { get_last_index(country_list) };
-        assert(country_list[last_index as u32] > 0);
-        if last_index < (N - 1) as i64 {
-            // If there are still 0s after the last non-0 element,
-            // then we need to check that the next element is 0
-            assert_eq(country_list[last_index as u32 + 1], 0);
-        }
-        // If the index is -1, then the nationality sum is greater than all the elements in the list
-        assert(country_list[last_index as u32] < issuing_country_sum);
-    }
-    // Assert that either the index is the first element of the list or the previous element is less than the nationality sum
-    else if closest_index == 0 {
-        // Assert that the country at the index is greater than the issuing country sum
-        assert(country_list[closest_index as u32] > issuing_country_sum);
-    } else if country_list[closest_index as u32 - 1] < issuing_country_sum {
-        // Assert that the country at the index is greater than the issuing country sum
-        assert(country_list[closest_index as u32] > issuing_country_sum);
-    } else {
-        // Otherwise it should fail
-        assert(false);
-    }
-    // If those two checks pass, then the issuing country is not in the country list
+    check_exclusion(issuing_country_sum, country_list);
 }
 
 /// Calculate the commitment of the country list using Poseidon2
@@ -214,4 +195,37 @@ fn test_country_list_sorting_check() {
     let country_list: [u32; 6] = [4608577, 4608579, 4608578, 0, 0, 0];
     let is_sorted = check_country_list_sorted(country_list);
     assert_eq(is_sorted, false);
+}
+
+#[test(should_fail_with = "Country list cannot contain 0s before the last non-0 element")]
+fn test_country_list_sorting_fail_with_0_in_middle() {
+    let country_list: [u32; 6] = [4608577, 0, 4608578, 4608579, 0, 0];
+    check_country_list_sorted(country_list);
+}
+
+#[test(should_fail_with = "Country list cannot start with 0")]
+fn test_country_list_sorting_fail_when_starts_with_0() {
+    let country_list: [u32; 6] = [0, 4608577, 4608578, 4608579, 0, 0];
+    check_country_list_sorted(country_list);
+}
+
+#[test]
+fn test_exclusion_check_pass() {
+    let country_list: [u32; 6] = [4608577, 4608582, 4608590, 0, 0, 0];
+    check_exclusion(4608576, country_list);
+    check_exclusion(4608580, country_list);
+    check_exclusion(4608589, country_list);
+    check_exclusion(4608591, country_list);
+}
+
+#[test(should_fail)]
+fn test_exclusion_check_fail() {
+    let country_list: [u32; 6] = [4608577, 4608578, 4608579, 0, 0, 0];
+    check_exclusion(4608577, country_list);
+}
+
+#[test(should_fail)]
+fn test_exclusion_check_fail_2() {
+    let country_list: [u32; 6] = [4608577, 4608578, 4608579, 0, 0, 0];
+    check_exclusion(4608578, country_list);
 }

--- a/src/noir/lib/exclusion-check/country/src/lib.nr
+++ b/src/noir/lib/exclusion-check/country/src/lib.nr
@@ -23,10 +23,28 @@ unconstrained fn get_last_index<let N: u32>(sorted_list: [u32; N]) -> i64 {
     index
 }
 
+pub fn check_country_list_sorted<let N: u32>(country_list: [u32; N]) -> bool {
+    let mut result = true;
+    let mut foundAZero = false;
+    for i in 0..N - 1 {
+        // Zeroes mark the end of the list (i.e. start of the padding)
+        if !foundAZero & (country_list[i + 1] == 0) {
+            foundAZero = true;
+        }
+        // If the current element is greater than the next element, then the list is not sorted
+        // We also want to make sure there are no duplicates so we actually check greater than or equal
+        if !foundAZero & (country_list[i] >= country_list[i + 1]) {
+            result = false;
+        }
+    }
+    result
+}
+
 /// Check if the nationality from the MRZ is not in the country list
 /// The list of countries is assumed to be sorted in ascending order
 /// So it must come either from a public input that can be independently checked
 /// or from a previous in-circuit check that the list is sorted
+/// If the list is not sorted, the proof will fail to generate
 ///
 /// # Arguments
 ///
@@ -35,6 +53,12 @@ unconstrained fn get_last_index<let N: u32>(sorted_list: [u32; N]) -> i64 {
 /// which are the Alpha-3 codes of the countries with each letter ASCII code put together using a weighted sum.
 /// e.g. for "FRA", the sum is 70 * 2^16 (0x10000) + 82 * 2^8 (0x100) + 65 = 4587520 + 20992 + 65 = 4608577
 pub fn check_nationality_exclusion<let N: u32>(dg1: [u8; 95], country_list: [u32; N]) {
+    // Check that the list is sorted in ascending order
+    assert(
+        check_country_list_sorted(country_list),
+        "Country list is not sorted in ascending order",
+    );
+
     let nationality_bytes = get_nationality_from_mrz(dg1);
     let nationality_sum: u32 = nationality_bytes[0] as u32 * 0x10000
         + nationality_bytes[1] as u32 * 0x100
@@ -75,7 +99,14 @@ pub fn check_nationality_exclusion<let N: u32>(dg1: [u8; 95], country_list: [u32
 /// The list of countries is assumed to be sorted in ascending order
 /// So it must come either from a public input that can be independently checked
 /// or from a previous in-circuit check that the list is sorted
+/// If the list is not sorted, the proof will fail to generate
 pub fn check_issuing_country_exclusion<let N: u32>(dg1: [u8; 95], country_list: [u32; N]) {
+    // Check that the list is sorted in ascending order
+    assert(
+        check_country_list_sorted(country_list),
+        "Country list is not sorted in ascending order",
+    );
+
     let issuing_country_bytes = get_issuing_country_from_mrz(dg1);
     let issuing_country_sum: u32 = issuing_country_bytes[0] as u32 * 0x10000
         + issuing_country_bytes[1] as u32 * 0x100
@@ -160,4 +191,27 @@ pub fn calculate_param_commitment_sha2<let N: u32>(
     }
     let hash = sha256::sha256_var(params, (N * 3 + 1) as u64);
     utils::pack_be_bytes_into_field::<32, 31>(hash)
+}
+
+#[test]
+fn test_country_list_sorting_check() {
+    // List in descending order, so not sorted in ascending order
+    let country_list: [u32; 6] = [4608578, 4608577, 4608579, 0, 0, 0];
+    let is_sorted = check_country_list_sorted(country_list);
+    assert_eq(is_sorted, false);
+
+    // List in ascending order
+    let country_list: [u32; 6] = [4608577, 4608578, 4608579, 0, 0, 0];
+    let is_sorted = check_country_list_sorted(country_list);
+    assert_eq(is_sorted, true);
+
+    // List with duplicates
+    let country_list: [u32; 6] = [4608577, 4608578, 4608579, 4608579, 0, 0];
+    let is_sorted = check_country_list_sorted(country_list);
+    assert_eq(is_sorted, false);
+
+    // List not in a particular order
+    let country_list: [u32; 6] = [4608577, 4608579, 4608578, 0, 0, 0];
+    let is_sorted = check_country_list_sorted(country_list);
+    assert_eq(is_sorted, false);
 }

--- a/src/ts/tests/circuits.test.ts
+++ b/src/ts/tests/circuits.test.ts
@@ -37,6 +37,8 @@ import {
   getUnixTimestamp,
   getNowTimestamp,
   getCurrentDateFromIntegrityProof,
+  getCountryWeightedSum,
+  rightPadArrayWithZeros,
 } from "@zkpassport/utils"
 import type { PackagedCertificate, Query } from "@zkpassport/utils"
 import { beforeAll, describe, expect, test } from "@jest/globals"
@@ -572,6 +574,30 @@ describe("subcircuits - RSA PKCS", () => {
       await circuit.destroy()
     }, 30000)
 
+    test("nationality - should fail if the list is not sorted", async () => {
+      const circuit = Circuit.from("exclusion_check_nationality_evm")
+      const query: Query = {
+        nationality: { out: ["FRA", "USA", "GBR"] },
+      }
+      const inputs = await getNationalityExclusionCircuitInputs(helper.passport as any, query, 3n)
+      // Override the country list to be unsorted
+      const unsortedCountryList: number[] = []
+      for (let i = 0; i < (query.nationality?.out ?? []).length; i++) {
+        const country: string = (query.nationality?.out ?? [])[i]
+        unsortedCountryList.push(getCountryWeightedSum(country as any))
+      }
+      inputs.country_list = rightPadArrayWithZeros(unsortedCountryList, 200) as any
+      if (!inputs) throw new Error("Unable to generate exclusion check circuit inputs")
+      // The circuit execution will throw an error if the list is not sorted
+      await expect(
+        circuit.prove(inputs, {
+          circuitName: `exclusion_check_nationality_evm`,
+          useCli: true,
+        }),
+      ).rejects.toThrow("Circuit execution failed: Country list is not sorted in ascending order")
+      await circuit.destroy()
+    }, 30000)
+
     test("issuing country", async () => {
       const circuit = Circuit.from("exclusion_check_issuing_country_evm")
       const query: Query = {
@@ -604,6 +630,34 @@ describe("subcircuits - RSA PKCS", () => {
       )
       const commitmentIn = getCommitmentInFromDisclosureProof(proof)
       expect(commitmentIn).toEqual(integrityCheckCommitment)
+      await circuit.destroy()
+    }, 30000)
+
+    test("issuing country - should fail if the list is not sorted", async () => {
+      const circuit = Circuit.from("exclusion_check_issuing_country_evm")
+      const query: Query = {
+        issuing_country: { out: ["FRA", "USA", "GBR"] },
+      }
+      const inputs = await getIssuingCountryExclusionCircuitInputs(
+        helper.passport as any,
+        query,
+        3n,
+      )
+      // Override the country list to be unsorted
+      const unsortedCountryList: number[] = []
+      for (let i = 0; i < (query.issuing_country?.out ?? []).length; i++) {
+        const country: string = (query.issuing_country?.out ?? [])[i]
+        unsortedCountryList.push(getCountryWeightedSum(country as any))
+      }
+      inputs.country_list = rightPadArrayWithZeros(unsortedCountryList, 200) as any
+      if (!inputs) throw new Error("Unable to generate exclusion check circuit inputs")
+      // The circuit execution will throw an error if the list is not sorted
+      await expect(
+        circuit.prove(inputs, {
+          circuitName: `exclusion_check_issuing_country_evm`,
+          useCli: true,
+        }),
+      ).rejects.toThrow("Circuit execution failed: Country list is not sorted in ascending order")
       await circuit.destroy()
     }, 30000)
   })


### PR DESCRIPTION
This PR adds a check in the country exclusion circuits (for both nationality and issuing country) that the list passed to the circuit is sorted in ascending order. 

Prior to this PR, this was already assumed to be sorted, but the verifier was the one to assume the cost of verifying the list was sorted (as it is part of the committed inputs, so it's checkable on the verifier side). In an offchain context, when the check is done by the verifier bundled in the SDK, this doesn't change much, as it doesn't take long to do it in TypeScript. But when verified onchain in EVM smart contracts, asserting the list is sorted can be a bit expensive. And since the cost to check that the list is sorted is quite low (less than 2k gates), it's worth shifting the cost back to the prover.

Note that the circuit doesn't actually sort the list, but expects a sorted list, so the proof will just fail to generate if the list is not sorted. The sorting is done out of the circuit when inputs are processed in the mobile app. The sorting could also happen in an unconstrained function, but this can be done later.

